### PR TITLE
on error, retry getting valid data from sensor

### DIFF
--- a/examples/WiFiShield/WiFiShield.ino
+++ b/examples/WiFiShield/WiFiShield.ino
@@ -45,6 +45,11 @@ void loop() {
 
   // Make 60 measurements and return the mean values
   sensor.readAverageData(data, 60);
+  if (data.error == 1) {
+    // no valid data to send. Therefore retry
+    // immediately without turning off the sensor.
+    return;
+  }
 
   // Send data to the hackAIR platform
   wifi_sendData(data);


### PR DESCRIPTION
I tested with my SDS011 sensor. In error case, the hackAIR system interprets the data as a transmitted 0µg measurement for both PM10 and PM25. This leads to an unrealistic data base!
Fix: For these cases and as a general improvement of the example, lets examine the error code!
Note: presumably, the Wemos D1 example should be modified also!